### PR TITLE
Flux DLL bugfix

### DIFF
--- a/flux/DllMain.cpp
+++ b/flux/DllMain.cpp
@@ -16,22 +16,22 @@ extern LONG CALLBACK VectoredHandler(
 static Hook Hooks[] =
 {
     /*File*/
-    {L"ntdll.dll", "NtWriteFile", &MyNtWriteFile, (void**)&OldNtWriteFile},
-    {L"ntdll.dll", "NtCreateFile", &MyNtCreateFile, (void**)&OldNtCreateFile},
-    {L"ntdll.dll", "NtQueryAttributesFile", &MyNtQueryAttributesFile, (void**)&OldNtQueryAttributesFile},
+    {L"ntdll.dll", "NtWriteFile", MyNtWriteFile, (void**)&OldNtWriteFile},
+    {L"ntdll.dll", "NtCreateFile", MyNtCreateFile, (void**)&OldNtCreateFile},
+    {L"ntdll.dll", "NtQueryAttributesFile", MyNtQueryAttributesFile, (void**)&OldNtQueryAttributesFile},
 
     /*Registry*/
-    {L"ntdll.dll", "NtSetValueKey", &MyNtSetValueKey, (void**)&OldNtSetValueKey},
-    {L"ntdll.dll", "NtOpenKeyEx", &MyNtOpenKeyEx, (void**)&OldNtOpenKeyEx},
+    {L"ntdll.dll", "NtSetValueKey", MyNtSetValueKey, (void**)&OldNtSetValueKey},
+    {L"ntdll.dll", "NtOpenKeyEx", MyNtOpenKeyEx, (void**)&OldNtOpenKeyEx},
 
     /*Process*/
-    {L"ntdll.dll", "NtCreateUserProcess", &MyNtCreateUserProcess, (void**)&OldNtCreateUserProcess},
-    {L"ntdll.dll", "NtCreateProcess", &MyNtCreateProcess, (void**)&OldNtCreateProcess},
-    {L"ntdll.dll", "NtCreateProcessEx", &MyNtCreateProcessEx, (void**)&OldNtCreateProcessEx},
+    {L"ntdll.dll", "NtCreateUserProcess", MyNtCreateUserProcess, (void**)&OldNtCreateUserProcess},
+    {L"ntdll.dll", "NtCreateProcess", MyNtCreateProcess, (void**)&OldNtCreateProcess},
+    {L"ntdll.dll", "NtCreateProcessEx", MyNtCreateProcessEx, (void**)&OldNtCreateProcessEx},
 	
     /*Misc*/
-    {L"ntdll.dll", "NtDelayExecution", &MyNtDelayExecution, (void**)&OldNtDelayExecution},
-    {L"ntdll.dll", "NtFreeVirtualMemory", &MyNtFreeVirtualMemory, (void**)&OldNtFreeVirtualMemory},
+    {L"ntdll.dll", "NtDelayExecution", MyNtDelayExecution, (void**)&OldNtDelayExecution},
+    {L"ntdll.dll", "NtFreeVirtualMemory", MyNtFreeVirtualMemory, (void**)&OldNtFreeVirtualMemory},
 
 };
 
@@ -90,5 +90,4 @@ BOOL WINAPI DllMain(
         break;
     }
     return true;
-
 }

--- a/flux/MemGuard.cpp
+++ b/flux/MemGuard.cpp
@@ -88,7 +88,7 @@ LONG CALLBACK VectoredHandler(
 				char outFile[MAX_PATH];
 				sprintf_s(outFile, MAX_PATH, "C:\\%s_EAF_%x", MaxLog::g_baseExe, lpBuffer.BaseAddress);
 
-                //LOG("sb", "FileName", outFile, "FileData", lpBuffer.BaseAddress, lpBuffer.RegionSize);
+                LOG("sb", "FileName", outFile, "FileData", lpBuffer.BaseAddress, lpBuffer.RegionSize);
          
 				HANDLE hFile = CreateFileA(outFile, GENERIC_WRITE, FILE_SHARE_READ, 0, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, 0);
 				if (hFile != INVALID_HANDLE_VALUE)
@@ -112,7 +112,7 @@ LONG CALLBACK VectoredHandler(
 	else if (ExceptionInfo->ExceptionRecord->ExceptionCode >= STATUS_ACCESS_VIOLATION && ExceptionInfo->ExceptionRecord->ExceptionCode <= STATUS_SXS_INVALID_DEACTIVATION)
 	{
 		/* Uncomment this to enable logging of crashes/access violations/etc */
-        //LOG("ll", "ExceptionCode", ExceptionInfo->ExceptionRecord->ExceptionCode, "ExceptionAddress", ExceptionInfo->ExceptionRecord->ExceptionAddress);
+        LOG("ll", "ExceptionCode", ExceptionInfo->ExceptionRecord->ExceptionCode, "ExceptionAddress", ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
 		wchar_t modSource[MAX_PATH];
         MaxLog::AddressToModule((DWORD_PTR)ExceptionInfo->ExceptionRecord->ExceptionAddress, modSource, MAX_PATH);

--- a/flux/hook.cpp
+++ b/flux/hook.cpp
@@ -57,7 +57,7 @@ void InstallHook(Hook * hook)
         totalSize += decodedInstructions[x].size;
     }
     // end distorm code
-    //log("Total size of tramp: %d", totalSize);
+    log("Total size of tramp: %d", totalSize);
     trampSize = totalSize;
 
 
@@ -107,7 +107,10 @@ void InstallHook(Hook * hook)
     int trampSize = 0;
 
     // allocate tramp buffer
-    trampAddr = VirtualAlloc(0, 37, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    trampAddr = VirtualAlloc(0, 37, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+
+    if (trampAddr == NULL)
+        return;
 
     DWORD trampAddrPtr = (DWORD)trampAddr;
 
@@ -152,7 +155,7 @@ void InstallHook(Hook * hook)
 
     trampSize = totalSize;
 
-    hook->oldFunc = (void*)trampAddr;
+    *(hook->oldFunc) = trampAddr;
 
     DWORD targetFuncPtr = (DWORD)targetFunc;
 
@@ -162,7 +165,6 @@ void InstallHook(Hook * hook)
     VirtualProtect((LPVOID)targetFunc, 37, PAGE_EXECUTE_READWRITE, &dwOld);
     //else
     //	Old_NtProtectVirtualMemory(GetCurrentProcess(), &targetFunc, &bytes, PAGE_EXECUTE_READWRITE, &dwOld);
-
     //copy instructions of function to tramp
     memcpy(trampAddr, targetFunc, totalSize);
     //create a jump to original function+5 from tramp

--- a/flux/hook.h
+++ b/flux/hook.h
@@ -37,6 +37,7 @@ NTSTATUS WINAPI MyNtOpenKeyEx
     ULONG              OpenOptions
 );
 
+
 extern NTSTATUS(NTAPI * OldNtCreateUserProcess)
 (
     PHANDLE ProcessHandle,
@@ -92,7 +93,8 @@ NTSTATUS WINAPI MyNtCreateProcess
     HANDLE ExceptionPort
 );
 
-NTSTATUS(WINAPI * OldNtCreateProcessEx)
+
+extern NTSTATUS(WINAPI * OldNtCreateProcessEx)
 (
     PHANDLE ProcessHandle,
     ACCESS_MASK DesiredAccess,
@@ -237,8 +239,8 @@ typedef struct
 {
     wchar_t * libName;
     char * functionName;
-    void * oldFunc;
-    void ** myFunc;
+    void * myFunc;
+    void ** oldFunc;
 } Hook;
 
 void InstallHook(Hook * hook);


### PR DESCRIPTION
Instrumentation library doesn't work, because of few terrible mistakes in hooking code. I've fixed some of them.